### PR TITLE
Lesson details page

### DIFF
--- a/src/components/LessonDetail.js
+++ b/src/components/LessonDetail.js
@@ -115,12 +115,15 @@ export const LessonDetail = ({ auth, props, pk }) => {
           <div className="previousInfo">
               <div className="previousLesson">
                 <h4> Last Lesson </h4>
-                <p>
-                  {previous.plan}
-                </p>
+                <div className="prevLsn">
+                  <p>
+                    {previous.plan}
+                  </p>
+                </div>
               </div>
               <div className="previousAssignment">
                 <h4> Last Assignment </h4>
+                <div className="prevAssign">
                 {previous.note && previous.note.length ? 
                   <p>
                     {previous.note[0].body} 
@@ -128,6 +131,7 @@ export const LessonDetail = ({ auth, props, pk }) => {
                   :
                   <p>no previous assignment exists</p>
                 }
+                </div>
               </div>
         </div>
       </div>

--- a/src/styles/lessonDetail.css
+++ b/src/styles/lessonDetail.css
@@ -100,6 +100,14 @@
   text-align: center;
 }
 
-/* .previousInfo {
-  margin-top: 2%;
-} */
+.prevLsn {
+  border: solid;
+  border-color: gray;
+  text-align: left;
+}
+
+.prevAssign {
+  border: solid;
+  border-color: gray;
+  text-align: left;
+}


### PR DESCRIPTION
lesson detail page finally renders previous lesson / assignment info at bottom of page. 
(minus bug that occurs when a student has more than one lesson scheduled in same day with same instructor) not priority fix at moment as that is an outlier scenario compared to function. 